### PR TITLE
added commander.js for help and version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,12 @@
   },
   "keywords": [],
   "dependencies": {
+    "commander": "^2.9.0",
     "extfs": "0.0.7",
     "fs-extra": "^0.26.2",
     "jethro": "^2.6.3"
+  },
+  "bin":{
+    "vispack": "src\vispack"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "scripts": {
     "test": "grunt test"
   },
+  "bin": {
+    "vispack": "src/vispack.js"
+  },
   "devDependencies": {
     "load-grunt-tasks": "*",
     "grunt-contrib-coffee": "~0.7",
@@ -47,8 +50,5 @@
     "extfs": "0.0.7",
     "fs-extra": "^0.26.2",
     "jethro": "^2.6.3"
-  },
-  "bin":{
-    "vispack": "src\vispack"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,15 +21,16 @@
       "url": "https://github.com/hci-lab/vispack/blob/master/LICENSE-MIT"
     }
   ],
+  "bin": {
+    "vispack": "src/vispack.js"
+  },
   "main": "src/vispack",
   "engines": {
     "node": ">=5.1.0"
   },
+  "preferGlobal": "true",
   "scripts": {
     "test": "grunt test"
-  },
-  "bin": {
-    "vispack": "src/vispack.js"
   },
   "devDependencies": {
     "load-grunt-tasks": "*",

--- a/package.json
+++ b/package.json
@@ -22,14 +22,15 @@
     }
   ],
   "bin": {
-    "vispack": "src/vispack.js"
+    "vispack": "dist/vispack.js"
   },
-  "main": "src/vispack",
+  "main": "dist/vispack",
   "engines": {
     "node": ">=5.1.0"
   },
   "preferGlobal": "true",
   "scripts": {
+    "preinstall": "coffee --bare --no-header --output dist --compile src",
     "test": "grunt test"
   },
   "devDependencies": {

--- a/src/vispack.coffee
+++ b/src/vispack.coffee
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 ###
 project     | vispack
 url         | https://github.com/hci-lab/vispack/blob/master/src/vispack.coffee
@@ -52,35 +51,6 @@ else if program.remove isnt true and program.install is undefined and program.re
     logger 'Info' , 'vispack removal' , stdout
     if error isnt null
       logger 'Error', 'vispack removal' , 'something wrong happened. try again later.'
-
-
-
-#commands = process.argv.slice 2
-#
-#if commands[0] is 'remove'
-#  plugin_name = commands[1]
-#  fs.getDirs process.cwd() + '\\plugins\\node_modules\\' + plugin_name, (err, dirs) ->
-#    if err
-#      console.log 'directory not found'
-#    else
-#      plugin_dir = process.cwd() + '\\plugins\\node_modules\\' + plugin_name
-#      fse.remove plugin_dir, (err)->
-#        if err
-#         logger 'Error', 'Remove', err
-#        logger 'Info' , 'Remove' , 'Success'
-#
-#
-#
-#
-#
-#if commands[0] is 'install'
-#  github_url = commands[1]
-#  prefix = './plugins'
-#  str = 'npm install --prefix ' + prefix + ' ' + github_url
-#  exec.exec str, (error,stdout,stderr) ->
-#    logger 'Info' , 'stdout' , stdout
-#    if error isnt null
-#      logger 'Error', 'exec error' , error
 
 #exports.awesome = ->
 #  "awesome"

--- a/src/vispack.coffee
+++ b/src/vispack.coffee
@@ -1,9 +1,10 @@
+#!/usr/bin/env node
 ###
 project     | vispack
 url         | https://github.com/hci-lab/vispack/blob/master/src/vispack.coffee
-module      |
+module      | vispack
 author      | YusufMohamed
-description |
+description | a cli utility to install and remove plugins.
 
 Copyright (c) 2015 HCI Lab. Licensed under the MIT license.
 ###
@@ -11,33 +12,75 @@ exec = require 'child_process'
 logger = require 'jethro'
 fs = require 'extfs'
 fse = require 'fs-extra'
-
-commands = process.argv.slice 2
-
-if commands[0] is 'remove'
-  plugin_name = commands[1]
-  fs.getDirs process.cwd() + '\\plugins\\node_modules\\' + plugin_name, (err, dirs) ->
-    if err
-      console.log 'directory not found'
-    else
-      plugin_dir = process.cwd() + '\\plugins\\node_modules\\' + plugin_name
-      fse.remove plugin_dir, (err)->
-        if err
-         logger 'Error', 'Remove', err
-        logger 'Info' , 'Remove' , 'Success'
+program = require 'commander'
+pjson = require '../package.json'
 
 
+program
+.version pjson.version
+.option '-I, --install [plugin]', 'add a new plugin'
+.option '-R, --remove [plugin]', 'remove installed plugin'
+
+program.on '--help', ()->
+  console.log '  Examples:'
+  console.log ''
+  console.log '    $ vispack install underscore'
+  console.log '    $ vispack remove underscore'
+  console.log ''
+
+program.parse(process.argv);
 
 
 
-if commands[0] is 'install'
-  github_url = commands[1]
+if program.install is true
+  logger 'Error', 'vispack', 'missing arguments. [vispack -h] for more help.'
+else if program.remove is true
+  logger 'Error', 'vispack', 'missing arguments. [vispack -h] for more help.'
+else if program.install isnt true and program.remove is undefined and program.install isnt undefined
+  package_name = program.install
   prefix = './plugins'
-  str = 'npm install --prefix ' + prefix + ' ' + github_url
-  exec.exec str, (error,stdout,stderr) ->
-    logger 'Info' , 'stdout' , stdout
+  str = 'npm install --prefix ' + prefix + ' ' + package_name
+  exec.exec str ,(error,stdout,stderr) ->
+    logger 'Info' , 'vispack installer' , stdout
     if error isnt null
-      logger 'Error', 'exec error' , error
+      logger 'Error', 'vispack installer' , 'something wrong happened. try again later.'
+else if program.remove isnt true and program.install is undefined and program.remove isnt undefined
+  package_name = program.remove
+  prefix = './plugins'
+  str = 'npm remove --prefix ' + prefix + ' ' + package_name
+  exec.exec str ,(error,stdout,stderr) ->
+    logger 'Info' , 'vispack removal' , stdout
+    if error isnt null
+      logger 'Error', 'vispack removal' , 'something wrong happened. try again later.'
+
+
+
+#commands = process.argv.slice 2
+#
+#if commands[0] is 'remove'
+#  plugin_name = commands[1]
+#  fs.getDirs process.cwd() + '\\plugins\\node_modules\\' + plugin_name, (err, dirs) ->
+#    if err
+#      console.log 'directory not found'
+#    else
+#      plugin_dir = process.cwd() + '\\plugins\\node_modules\\' + plugin_name
+#      fse.remove plugin_dir, (err)->
+#        if err
+#         logger 'Error', 'Remove', err
+#        logger 'Info' , 'Remove' , 'Success'
+#
+#
+#
+#
+#
+#if commands[0] is 'install'
+#  github_url = commands[1]
+#  prefix = './plugins'
+#  str = 'npm install --prefix ' + prefix + ' ' + github_url
+#  exec.exec str, (error,stdout,stderr) ->
+#    logger 'Info' , 'stdout' , stdout
+#    if error isnt null
+#      logger 'Error', 'exec error' , error
 
 #exports.awesome = ->
 #  "awesome"

--- a/src/vispack.coffee
+++ b/src/vispack.coffee
@@ -1,3 +1,5 @@
+`#!/usr/bin/env node
+`
 ###
 project     | vispack
 url         | https://github.com/hci-lab/vispack/blob/master/src/vispack.coffee
@@ -7,12 +9,12 @@ description | a cli utility to install and remove plugins.
 
 Copyright (c) 2015 HCI Lab. Licensed under the MIT license.
 ###
-exec = require 'child_process'
-logger = require 'jethro'
-fs = require 'extfs'
-fse = require 'fs-extra'
+exec    = require 'child_process'
+logger  = require 'jethro'
+fs      = require 'extfs'
+fse     = require 'fs-extra'
 program = require 'commander'
-pjson = require '../package.json'
+pjson   = require '../package.json'
 
 
 program
@@ -37,16 +39,18 @@ else if program.remove is true
   logger 'Error', 'vispack', 'missing arguments. [vispack -h] for more help.'
 else if program.install isnt true and program.remove is undefined and program.install isnt undefined
   package_name = program.install
-  prefix = './plugins'
-  str = 'npm install --prefix ' + prefix + ' ' + package_name
+  install_dir  = process.env.APPDATA + '/npm/node_modules/vispack' || (process.platform == 'darwin' ? process.env.HOME + 'Library/Preference/npm/node_modules/vispack' : '/usr/lib/node_modules/vispack')
+  prefix       = install_dir + '/plugins'
+  str          = 'npm install --prefix ' + prefix + ' ' + package_name
   exec.exec str ,(error,stdout,stderr) ->
     logger 'Info' , 'vispack installer' , stdout
     if error isnt null
       logger 'Error', 'vispack installer' , 'something wrong happened. try again later.'
 else if program.remove isnt true and program.install is undefined and program.remove isnt undefined
   package_name = program.remove
-  prefix = './plugins'
-  str = 'npm remove --prefix ' + prefix + ' ' + package_name
+  install_dir  = process.env.APPDATA + '/npm/node_modules/vispack' || (process.platform == 'darwin' ? process.env.HOME + 'Library/Preference/npm/node_modules/vispack' : '/var/local/npm/node_modules/vispack')
+  prefix       = install_dir + '/plugins'
+  str          = 'npm remove --prefix ' + prefix + ' ' + package_name
   exec.exec str ,(error,stdout,stderr) ->
     logger 'Info' , 'vispack removal' , stdout
     if error isnt null

--- a/test/vispack_test.coffee
+++ b/test/vispack_test.coffee
@@ -6,7 +6,7 @@ sinonChai = require('sinon-chai')
 
 chai.use(sinonChai)
 
-vispack = require('../src/vispack.coffee')
+#vispack = require('../src/vispack.coffee')
 
 describe "test", ->
   beforeEach (done) ->


### PR DESCRIPTION
i'm facing some problems with coffeescript as i can't get the cli to work like `vispack install plugin` for 2 reasons:
- i can't make shebangs `#!/usr/bin/env node` in top of vispack.coffee as the there is `// compiled with coffeescript` commend in first line
- when i try `npm install -g` to install the vispack package globally. node can't find the .js files to link as it only finds the coffeescript files. we need something like preinstall script.
  this also should resolve #6 .
